### PR TITLE
Add environment variables

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,16 @@ build_dir=$1
 cache_dir=$2
 env_dir=$3
 
+#Load environment variables that may be needed to boot rails.
+blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+if [ -d "$env_dir" ]; then
+  for e in $(ls $env_dir); do
+    echo "$e" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+    :
+  done
+fi
+
 db_url=`cat ${3}/DATABASE_URL`
 migrations_done=(`psql ${db_url} --command="SELECT * FROM schema_migrations ORDER BY version DESC" --tuples-only`)
 


### PR DESCRIPTION
Pistachio crashes when attempting to do a database migration, because some environment variables are not set when the script is running. Instead, they variables are changed into files, and the env_dir is passed in instead.

This change will load the environment variables from the env_dir.

@farisj Please Review

Credit for this code goes to https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks/blob/master/bin/compile